### PR TITLE
A missing newline after a paragraph for TextRenderer

### DIFF
--- a/src/main/java/com/watermark_apps/downmarker/renderer/TextRenderer.java
+++ b/src/main/java/com/watermark_apps/downmarker/renderer/TextRenderer.java
@@ -32,6 +32,6 @@ public class TextRenderer implements IRenderer {
 
     @Override
     public String renderParagraph(String text) {
-        return text;
+        return text + "\n";
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 0.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | -
| License       | MIT

This fixes a bug in `TextRenderer` that a newline is missing after a paragraph.
